### PR TITLE
Fix links to core ratio

### DIFF
--- a/sass/plugin/_scale.scss
+++ b/sass/plugin/_scale.scss
@@ -1,7 +1,7 @@
 /// # QuickStart: Scale
 /// Sass size & scale management tools:
 /// - Gather all your sizes into a single map
-/// - Generate new sizes based on [modular scales][core-ratios.html]
+/// - Generate new sizes based on [modular scales][core-ratio.html]
 ///   or arbitrary functions
 /// - Convert between relative units
 /// - Access sizes on the fly

--- a/sass/plugin/layout/_ratio.scss
+++ b/sass/plugin/layout/_ratio.scss
@@ -11,7 +11,7 @@
 ///   for custom source-palette
 /// @since 0.1.0 -
 /// - BREAKING: Uses the new [shared](core.html) map syntax,
-///   and [ratio](core-ratios.html) settings
+///   and [ratio](core-ratio.html) settings
 ///
 /// @group layout-ratios
 /// @example scss
@@ -51,7 +51,7 @@
 ///   for custom source-palette
 /// @since 0.1.0 -
 /// - BREAKING: Uses the new [shared](core.html) map syntax,
-///   and [ratio](core-ratios.html) settings
+///   and [ratio](core-ratio.html) settings
 ///
 /// @group layout-ratios
 /// @example scss


### PR DESCRIPTION
Fixes scss documentation links to Core Layout & Type Ratios docs pages in:
* `plugin/_scale.scss`
* `plugin/layout/_ratio.scss`