### PR TITLE
Updated parser to use inspect() instead of quote()

### DIFF
--- a/sass/core/_api.scss
+++ b/sass/core/_api.scss
@@ -292,7 +292,7 @@
   $key,
   $do: null
 ) {
-  $val: map-get($map, $key) or $key;
+  $val: if(map-has-key($map, $key), map-get($map, $key), $key);
 
   // Handle deep keys
   @if ($val == $key)

--- a/sass/core/_parser.scss
+++ b/sass/core/_parser.scss
@@ -265,7 +265,7 @@ $_a_source-memo: ();
   $source
 ) {
   // Check memo…
-  $memo: map-get($_a_source-memo, quote($source));
+  $memo: map-get($_a_source-memo, inspect($source));
 
   @if $memo {
     @return $memo;
@@ -284,7 +284,7 @@ $_a_source-memo: ();
   }
 
   // Store to memo…
-  $_a_source-memo: map-merge($_a_source-memo, (quote($source): $flat)) !global;
+  $_a_source-memo: map-merge($_a_source-memo, (inspect($source): $flat)) !global;
 
   // Done…
   @return $flat;


### PR DESCRIPTION
This corrects an issue being thrown by the dart implementation of the sass compiler, as described in issue #36. 