### PR TITLE
Updated get-token() to use map-has-key()

### DIFF
--- a/sass/core/_api.scss
+++ b/sass/core/_api.scss
@@ -292,7 +292,7 @@
   $key,
   $do: null
 ) {
-  $val: map-get($map, $key) or $key;
+  $val: if(map-has-key($map, $key), map-get($map, $key), $key);
 
   // Handle deep keys
   @if ($val == $key)


### PR DESCRIPTION
This allows for maps to contain falsey values, since we are no longer relying on the null thrown by map-get() to determine if a key exists.