### PR TITLE
Add possibility to configure font-display in @font-face

### DIFF
--- a/sass/plugin/type/_fonts.scss
+++ b/sass/plugin/type/_fonts.scss
@@ -184,11 +184,12 @@
 
   @if (length($variants) > 0) {
     $unicode: map-get($font, 'unicode-range');
+    $display: map-get($font, 'display');
 
     @each $variant, $data in $variants {
       $weight: nth($variant, 1);
       $style: nth($variant, 2);
-      @include _a_import-font-face($name, $weight, $style, $data, $unicode);
+      @include _a_import-font-face($name, $weight, $style, $data, $unicode, $display);
     }
   }
 }

--- a/sass/plugin/type/_helpers.scss
+++ b/sass/plugin/type/_helpers.scss
@@ -291,7 +291,8 @@ $_a_FONT-FORMATS: (
   $weight,
   $style,
   $data,
-  $unicode: null
+  $unicode: null,
+  $display: 'auto'
 ) {
   // Special handling of eot with local or data
   $eot: map-get($data, 'eot');
@@ -346,6 +347,7 @@ $_a_FONT-FORMATS: (
       font-family: $name;
       font-style: $style;
       font-weight: $weight;
+      font-display: $display;
       src: _a_font-src-list($data);
       unicode-range: $unicode;
     }
@@ -355,6 +357,7 @@ $_a_FONT-FORMATS: (
       font-family: $name;
       font-style: $style;
       font-weight: $weight;
+      font-display: $display;
       src: $eot;
       src: _a_font-src-list($data);
       unicode-range: $unicode;

--- a/sass/plugin/type/_helpers.scss
+++ b/sass/plugin/type/_helpers.scss
@@ -338,6 +338,7 @@ $_a_FONT-FORMATS: (
       font-family: $name;
       font-style: $style;
       font-weight: $weight;
+      font-display: $display;
       src: $eot;
       unicode-range: $unicode;
     }


### PR DESCRIPTION
As supposed by Google I would like to set the css value `font-display: swap` for `@font-face` definitions: https://web.dev/font-display/