### PR TITLE
migrate to math.div() from slash division

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "gulp-stylelint": "^13.0.0",
     "mocha": "^8.3.0",
     "node-sass": "^5.0.0",
-    "sass": "^1.32.8",
+    "sass": "^1.33.0",
     "sass-true": "^5.0.0",
     "sassdoc": "^2.7.3",
     "sassdoc-theme-herman": "^4.0.0",

--- a/sass/core/_lists.scss
+++ b/sass/core/_lists.scss
@@ -32,6 +32,8 @@
 ///   The original list, with item removed
 /// @throws `$index` must be a non-zero integer
 /// @throws `$index` is too large for the list length
+@use "sass:math";
+
 @function _a_remove-nth(
   $list,
   $index
@@ -113,7 +115,7 @@
   $large: $less;
 
   @if length($list) > 1 {
-    $seed: nth($list, ceil(length($list) / 2));
+    $seed: nth($list, ceil(math.div(length($list), 2)));
     $seed-length: str-length('#{$seed}');
 
     @each $item in $list {

--- a/sass/core/_math.scss
+++ b/sass/core/_math.scss
@@ -33,6 +33,8 @@
 /// @return {number} -
 ///   The calculated results of adding
 ///   `$num1` and `$num2`
+@use "sass:math";
+
 @function _a_plus(
   $num1,
   $num2
@@ -137,7 +139,7 @@
   $num1,
   $num2
 ) {
-  @return $num1 / $num2;
+  @return math.div($num1, $num2);
 }
 @include _a_register-function('_a_divide', 'divide', '/');
 

--- a/sass/core/_pow.scss
+++ b/sass/core/_pow.scss
@@ -9,6 +9,8 @@
 
 // Constants
 // ---------
+@use "sass:math";
+
 $_LN2: 0.6931471805599453;
 $_SQRT2: 1.4142135623730951;
 
@@ -53,7 +55,7 @@ $_SQRT2: 1.4142135623730951;
       $exp: floor($exp * 0.5);
       $base: $base * $base;
     }
-    @return if($s != 0, 1 / $r, $r);
+    @return if($s != 0, math.div(1, $r), $r);
   } @else if $base == 0 and $exp > 0 {
     @return 0;
   } @else {
@@ -85,7 +87,7 @@ $_SQRT2: 1.4142135623730951;
   $i: 1;
   @for $n from 0 to 24 {
     $ret: $ret + $i;
-    $i: $i * $x / ($n + 1);
+    $i: math.div($i * $x, $n + 1);
   }
   @return $ret;
 }
@@ -115,14 +117,14 @@ $_SQRT2: 1.4142135623730951;
   $b: null
 ) {
   @if $b != null {
-    @return _a_log($x) / _a_log($b);
+    @return math.div(_a_log($x), _a_log($b));
   }
 
   @if $x <= 0 {
-    @return 0 / 0;
+    @return math.div(0, 0);
   }
-  $k: nth(_a_frexp($x / $_SQRT2), 2);
-  $x: $x / _a_ldexp(1, $k);
+  $k: nth(_a_frexp(math.div($x, $_SQRT2)), 2);
+  $x: math.div($x, _a_ldexp(1, $k));
 
   @return $_LN2 * $k + _a_log-approx($x);
 }
@@ -136,7 +138,7 @@ $_SQRT2: 1.4142135623730951;
 @function _a_log-approx(
   $x
 ) {
-  $x: ($x - 1) / ($x + 1);
+  $x: math.div($x - 1, $x + 1);
   $x2: $x * $x;
   $i: 1;
   $s: $x;
@@ -145,7 +147,7 @@ $_SQRT2: 1.4142135623730951;
     $x: $x * $x2;
     $i: $i + 2;
     $sp: $s;
-    $s: $s + $x / $i;
+    $s: $s + math.div($x, $i);
   }
   @return 2 * $s;
 }
@@ -174,7 +176,7 @@ $_SQRT2: 1.4142135623730951;
     }
   } @else if $x >= 1 {
     @while $x >= 1 {
-      $x: $x / 2;
+      $x: math.div($x, 2);
       $exp: $exp + 1;
     }
   }
@@ -193,7 +195,7 @@ $_SQRT2: 1.4142135623730951;
   $x,
   $exp
 ) {
-  $b: if($exp >= 0, 2, 1 / 2);
+  $b: if($exp >= 0, 2, math.div(1, 2));
   @if $exp < 0 {
     $exp: $exp * -1;
   }

--- a/sass/core/_ratios.scss
+++ b/sass/core/_ratios.scss
@@ -24,6 +24,8 @@
 ///
 /// @type map
 /// @see $_a_RATIOS
+@use "sass:math";
+
 $ratios: () !default;
 
 
@@ -99,17 +101,17 @@ $ratios: () !default;
 /// @access public
 $_a_RATIOS: (
   '_octave': 2,
-  '_major-seventh': (15 / 8),
-  '_minor-seventh': (16 / 9),
-  '_major-sixth': (5 / 3),
-  '_minor-sixth': (8 / 5),
-  '_fifth': (3 / 2),
-  '_augmented-fourth': (45 / 32),
-  '_fourth': (4 / 3),
-  '_major-third': (5 / 4),
-  '_minor-third': (6 / 5),
-  '_major-second': (9 / 8),
-  '_minor-second': (16 / 15),
+  '_major-seventh': math.div(15, 8),
+  '_minor-seventh': math.div(16, 9),
+  '_major-sixth': math.div(5, 3),
+  '_minor-sixth': math.div(8, 5),
+  '_fifth': math.div(3, 2),
+  '_augmented-fourth': math.div(45, 32),
+  '_fourth': math.div(4, 3),
+  '_major-third': math.div(5, 4),
+  '_minor-third': math.div(6, 5),
+  '_major-second': math.div(9, 8),
+  '_minor-second': math.div(16, 15),
 
   '_photo': '#_fifth',
   '_classic': '#_fourth',

--- a/sass/plugin/color/_contrast.scss
+++ b/sass/plugin/color/_contrast.scss
@@ -9,6 +9,8 @@
 /// [WCAG]: https://www.w3.org/TR/2008/REC-WCAG20-20081211/#visual-audio-contrast-contrast
 ///
 /// @access private
+@use "sass:math";
+
 $WCAG-CONTRAST: (
   'AA-large': 3,
   'AA': 4.5,
@@ -315,7 +317,7 @@ $WCAG-CONTRAST: (
   $darker: min($base-lumin, $contrast-lumin);
   $lighter: max($base-lumin, $contrast-lumin);
 
-  $ratio: ($lighter + 0.05) / ($darker + 0.05);
+  $ratio: math.div($lighter + 0.05, $darker + 0.05);
 
   $require: _a_valid-contrast($require);
 
@@ -352,12 +354,12 @@ $WCAG-CONTRAST: (
       $function: get-function($component);
     }
 
-    $value: call($function, $color) / 255;
+    $value: math.div(call($function, $color), 255);
 
     @if ($value < 0.03928) {
-      $value: $value / 12.92;
+      $value: math.div($value, 12.92);
     } @else {
-      $base: ($value + 0.055) / 1.055;
+      $base: math.div($value + 0.055, 1.055);
       $value: _a_pow($base, 2.4);
     }
 

--- a/sass/plugin/color/_themes.scss
+++ b/sass/plugin/color/_themes.scss
@@ -33,6 +33,8 @@
 /// @param {integer} $range [3] -
 ///   number of dark and light variations desired,
 ///   in addition to the midpoint
+@use "sass:math";
+
 @function shades-of(
   $origin,
   $range: 3
@@ -50,7 +52,7 @@
     $light: lightness($color);
     $light: if($light == 0, 0.00000001%, $light);
     $lum: luminance($color);
-    $avg: (($light / 100%) + $lum) / 2;
+    $avg: math.div(($light / 100%) + $lum, 2);
     $pos: (ceil($avg * $count) - ($range + 1));
 
     @for $i from (0 - $range) through $range {
@@ -61,7 +63,7 @@
 
       @if ($do) {
         $distance: abs(if(($do == 'dark'), (0 - $range), $range) - $pos);
-        $interval: percentage(1 / ($distance + 0.25));
+        $interval: percentage(math.div(1, $distance + 0.25));
         $amount: (abs($diff) - 0.5) * $interval;
         $value: $value (map-get($adjust, $do): $amount);
       }
@@ -99,7 +101,7 @@
   $colors...
 ) {
   $gradient: ();
-  $width: 100% / length($colors);
+  $width: math.div(100%, length($colors));
 
   @for $i from 1 through length($colors) {
     $pop: color(nth($colors, $i));

--- a/sass/plugin/layout/_ratio.scss
+++ b/sass/plugin/layout/_ratio.scss
@@ -28,6 +28,8 @@
 /// @param {map} $source [$ratios] -
 ///   Optional accoutrement-format map of ratios to use as the origin palette
 ///   (in addition to the provided defaults)
+@use "sass:math";
+
 @mixin fluid-ratio(
   $ratio: '_widescreen',
   $width: 100%,
@@ -76,5 +78,5 @@
 ) {
   $ratio: ratio($ratio, $source: $source);
 
-  @return (1 / $ratio) * $width;
+  @return math.div(1, $ratio) * $width;
 }

--- a/sass/plugin/scale/_units.scss
+++ b/sass/plugin/scale/_units.scss
@@ -12,6 +12,8 @@
 ///   The number to be converted to px if comparable.
 /// @return {number | false} -
 ///   Either the `px` value of the converted `$length` or `false`.
+@use "sass:math";
+
 @function _a_get-px(
   $length
 ) {
@@ -121,7 +123,7 @@
   @if ($from-unit == '') {
     @return _a_get-number($to-unit, 'allow-relative') + $length;
   } @else if ($to-unit == '') {
-    @return $length / ($length * 0 + 1);
+    @return math.div($length, $length * 0 + 1);
   }
 
   // Easily comparable units
@@ -163,7 +165,7 @@
   // Special conversion for browser-default ems (needed in media-queries)
   @if ($to-unit == 'browser-ems') {
     $size: convert-units($length, 'px', $from-context);
-    @return $size / $_BROWSER-DEFAULT-FONT-SIZE * 1em;
+    @return math.div($size, $_BROWSER-DEFAULT-FONT-SIZE) * 1em;
   }
 
   // Convert relative length to pixels
@@ -172,26 +174,26 @@
 
   // Convert relative units using the from-context parameter.
   @if $from-unit == 'em' {
-    $px-length: $length * $from-context / 1em;
+    $px-length: math.div($length * $from-context, 1em);
   } @else if $from-unit == 'rem' {
-    $px-length: $length * $root-size / 1rem;
+    $px-length: math.div($length * $root-size, 1rem);
   } @else if $from-unit == '%' {
-    $px-length: $length * $from-context / 100%;
+    $px-length: math.div($length * $from-context, 100%);
   } @else if $from-unit == 'ex'  {
-    $px-length: $length * $from-context / 2ex;
+    $px-length: math.div($length * $from-context, 2ex);
   }
 
   // Convert length in pixels to the output unit
   @if $to-zero {
     @return $to-zero + $px-length;
   } @else if $to-unit == 'em' {
-    @return $px-length * 1em / $to-context;
+    @return math.div($px-length * 1em, $to-context);
   } @else if $to-unit == 'rem' {
-    @return $px-length * 1rem / $root-size;
+    @return math.div($px-length * 1rem, $root-size);
   } @else if $to-unit == '%' {
-    @return $px-length * 100% / $to-context;
+    @return math.div($px-length * 100%, $to-context);
   } @else if $to-unit == 'ex' {
-    @return $px-length * 2ex / $to-context;
+    @return math.div($px-length * 2ex, $to-context);
   }
 
   $warn: 'Failed to convert `#{$length}` into `#{$to-units}` units';

--- a/test/core/_ratios.scss
+++ b/test/core/_ratios.scss
@@ -1,5 +1,7 @@
 // Core Ratio Tests
 // ================
+@use "sass:math";
+
 @include test-module('Core Ratios') {
 
 
@@ -9,7 +11,7 @@
   @include it('Returns a named ratio') {
     @include assert-equal(
       ratio('_fifth'),
-      (3 / 2)
+      math.div(3, 2)
     );
   }
 
@@ -36,13 +38,13 @@
 
   @include it('Accepts custom source') {
     $custom: (
-      'special': (16 / 9),
+      'special': math.div(16, 9),
       'custom-source': '#special',
     );
 
     @include assert-equal(
       ratio('custom-source', $source: $custom),
-      (16 / 9)
+      math.div(16, 9)
     );
   }
 }
@@ -51,11 +53,11 @@
 @include describe('Add Ratios [mixin]') {
   $old: $ratios;
   $new1: (
-    'test': (1 / 3),
-    'other': (1 / 2),
+    'test': math.div(1, 3),
+    'other': math.div(1, 2),
     );
   $new2: (
-    'test': (16 / 9)
+    'test': math.div(16, 9)
   );
   @include add-ratios($new1, $new2);
   @include it('Adds maps to the $ratios global') {

--- a/test/plugin/_layout.scss
+++ b/test/plugin/_layout.scss
@@ -1,6 +1,8 @@
 // Layout Tests
 // ============
 
+@use "sass:math";
+
 $sizes: (
   'off-canvas': 30em,
   'page': 50em,
@@ -16,7 +18,7 @@ $breakpoints: (
 );
 
 $aspect-ratios: (
-  'mine': 13 / 4,
+  'mine': math.div(13, 4),
   'retro': '#_classic',
 );
 

--- a/test/plugin/color/_themes.scss
+++ b/test/plugin/color/_themes.scss
@@ -1,13 +1,15 @@
 // Color Theme Tests
 // =================
+@use "sass:math";
+
 @include test-module('Color: Themes') {
 
 
 // Shades Of [function]
 // --------------------
 @include describe('Shades Of [function]') {
-  $dint: percentage(1 / 1.25);
-  $lint: percentage(1 / 3.25);
+  $dint: percentage(math.div(1, 1.25));
+  $lint: percentage(math.div(1, 3.25));
   @include it('Generates a range of shades based on the origin color') {
     @include assert-equal(
       shades-of('simple', 2),
@@ -22,8 +24,8 @@
   }
 
   @include it('Generates a range of shades based on a map') {
-    $int1: percentage(1 / 1.25);
-    $int2: percentage(1 / 2.25);
+    $int1: percentage(math.div(1, 1.25));
+    $int2: percentage(math.div(1, 2.25));
     $map: (
       'one': red,
       'two': yellow,

--- a/test/plugin/layout/_ratio.scss
+++ b/test/plugin/layout/_ratio.scss
@@ -1,5 +1,7 @@
 // Ratio Tests
 // ===========
+@use "sass:math";
+
 @include test-module('Layout: Aspect Ratios') {
 
 
@@ -7,7 +9,7 @@
 // ----------------------
 @include describe('Fluid Ratio [function]') {
   @include it('Generates height from ratio') {
-    $expect: (3 / 4) * 50%;
+    $expect: math.div(3, 4) * 50%;
 
     @include assert-equal(
       fluid-ratio('_classic', 50%),
@@ -16,7 +18,7 @@
   }
 
   @include it('Gets ratio from local source') {
-    $local: ('new': (2 / 1));
+    $local: ('new': math.div(2, 1));
     @include assert-equal(
       fluid-ratio('new', $source: $local),
       50%
@@ -45,7 +47,7 @@
 }
 
   @include it('Gets ratio from local source') {
-    $local: ('new': (2 / 1));
+    $local: ('new': math.div(2, 1));
     @include assert{
       @include output {
         @include fluid-ratio('new', 50%, $source: $local);

--- a/yarn.lock
+++ b/yarn.lock
@@ -962,7 +962,7 @@ cheerio@^1.0.0-rc.2, cheerio@^1.0.0-rc.5:
     parse5 "^6.0.0"
     parse5-htmlparser2-tree-adapter "^6.0.0"
 
-chokidar@3.5.1, "chokidar@>=2.0.0 <4.0.0":
+chokidar@3.5.1, "chokidar@>=3.0.0 <4.0.0":
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
   integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
@@ -4825,12 +4825,12 @@ sass-true@^5.0.0:
     lodash.foreach "^4.5.0"
     lodash.last "^3.0.0"
 
-sass@^1.32.8:
-  version "1.32.8"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.32.8.tgz#f16a9abd8dc530add8834e506878a2808c037bdc"
-  integrity sha512-Sl6mIeGpzjIUZqvKnKETfMf0iDAswD9TNlv13A7aAF3XZlRPMq4VvJWBC2N2DXbp94MQVdNSFG6LfF/iOXrPHQ==
+sass@^1.33.0:
+  version "1.34.1"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.34.1.tgz#30f45c606c483d47b634f1e7371e13ff773c96ef"
+  integrity sha512-scLA7EIZM+MmYlej6sdVr0HRbZX5caX5ofDT9asWnUJj21oqgsC+1LuNfm0eg+vM0fCTZHhwImTiCU0sx9h9CQ==
   dependencies:
-    chokidar ">=2.0.0 <4.0.0"
+    chokidar ">=3.0.0 <4.0.0"
 
 sassdoc-extras@^2.5.0:
   version "2.5.1"


### PR DESCRIPTION
## Cute animal pic
![image](https://user-images.githubusercontent.com/41588129/121533164-4e747d80-ca00-11eb-9f51-456e6bde71d0.png)

_Because everyone likes pictures of [animals](https://unsplash.com/t/animals)._

Fixes: [#73]( https://github.com/oddbird/accoutrement/issues/73
)
## Link to Trello card (if applicable)
https://trello.com/c/7tuFeKMy/39-replace-slash-division-with-mathdiv
_If this PR relates to a Trello card, don't forget to reference this PR on the card as well._



## Description
_The commit messages say what you did; this should explain why and/or how._
- [x ] Description is in Trello card



