### PR TITLE
Edit modules list on README /  docs index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,26 +61,26 @@ you can use the default "tools" using only:
 
 ## Modules for common data types
 
+- **[Utilities](https://www.oddbird.net/accoutrement/docs/utils.html)** --
+  For helpers with Sass lists, strings, and maps
+- **[Ratios](https://www.oddbird.net/accoutrement/docs/ratios.html)** --
+  For managing aspect and typography ratios
+  (several common ratios are provided)
 - **[Animate](https://www.oddbird.net/accoutrement/docs/animate.html)** --
   For managing CSS transitions and animations
 - **[Color](https://www.oddbird.net/accoutrement/docs/color.html)** --
   For managing CSS colors and contrast-ratios
+- **[Layout](https://www.oddbird.net/accoutrement/docs/layout.html)** --
+  For managing CSS sizes: typographic scales, spacing, etc.
 - **[Scale](https://www.oddbird.net/accoutrement/docs/scale.html)** --
   For managing CSS sizes: typographic scales, spacing, etc.
 - **[Type](https://www.oddbird.net/accoutrement/docs/type.html)** --
   For managing webfonts, generated content, and other text needs
-- **[Ratios](https://www.oddbird.net/accoutrement/docs/ratios.html)** --
-  For managing aspect and typography ratios
-  (several common ratios are provided)
-- **[Variables](https://www.oddbird.net/accoutrement/docs/vars.html)** --
-  For converting Sass maps and variables into CSS custom properties
-- **[Utilities](https://www.oddbird.net/accoutrement/docs/utils.html)** --
-  For helpers with Sass lists, strings, and maps
 
 ## Tokens
 
-The **Token** module provides
-a special syntax for managing design tokens
+The [**Tokens**](https://www.oddbird.net/accoutrement/docs/tokens.html)
+module provides a special syntax for managing design tokens
 with Sass "map" objects:
 
 ```scss


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&600se)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


<!--
## Description
Uncomment if you want to provide a custom description.
-->


## Steps to test/reproduce
See the list of Accoutrement modules on the Accoutrement docs index page `/accoutrement/docs/` under the "Modules for common data types" section.

The list of modules should match the top level headings in the sidebar on the docs page, except for the `Tokens` module which appears in its own section after the modules list. 

_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._


## Show me

![bild](https://user-images.githubusercontent.com/41588129/160140369-21675a6e-7a2e-455f-8bce-2b6f221094c4.png)

_Provide screenshots/animated gifs/videos if necessary._


