### PR TITLE
Remove unnecessary lines in split() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Accoutrement Changelog
 
+## 4.0.2 - ##/##/22
+
+- [Sass Utilities][utils]:
+
+  - NEW: Removed unnecessary string length checks in the
+    [`split()`](https://www.oddbird.net/accoutrement/docs/utils.html#function--split) function.
+
 ## 4.0.1 - 03/28/22
 
 - INTERNAL: Upgrade dev dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Accoutrement Changelog
 
-## 4.0.2 - ##/##/22
+## UNRELEASED
 
 - [Sass Utilities][utils]:
 
   - NEW: Removed unnecessary string length checks in the
-    [`split()`](https://www.oddbird.net/accoutrement/docs/utils.html#function--split) function.
+    [`split()`](https://www.oddbird.net/accoutrement/docs/utils.html#function--split)
+    function.
 
 ## 4.0.1 - 03/28/22
 

--- a/sass/utils/_string.scss
+++ b/sass/utils/_string.scss
@@ -210,8 +210,6 @@
 /// However, it's available in all Accoutrement maps
 /// as either `'str-split'` or `'split'`.
 ///
-/// @since 4.0.2 -
-/// - New: Removed extra string length checks when `$separator` is empty
 /// @since 4.0.0 -
 /// - BREAKING: Renamed from `_a_split` to `split`
 /// - NEW: Available for direct usage

--- a/sass/utils/_string.scss
+++ b/sass/utils/_string.scss
@@ -257,14 +257,8 @@
 
       @if ($separator == '') {
         $length: string.length($string);
-
-        @if ($length > 1) {
-          $slice: string.slice($string, 1, 1);
-          $string: string.slice($string, 2);
-        } @else {
-          $slice: if(($length == 1), $string, '');
-          $string: null;
-        }
+        $slice: string.slice($string, 1, 1);
+        $string: string.slice($string, 2);
       } @else if ($index) {
         $slice: string.slice($string, 1, $index - 1);
         $string: string.slice($string, $index + string.length($separator));

--- a/sass/utils/_string.scss
+++ b/sass/utils/_string.scss
@@ -210,6 +210,8 @@
 /// However, it's available in all Accoutrement maps
 /// as either `'str-split'` or `'split'`.
 ///
+/// @since 4.0.2 -
+/// - New: Removed extra string length checks when `$separator` is empty
 /// @since 4.0.0 -
 /// - BREAKING: Renamed from `_a_split` to `split`
 /// - NEW: Available for direct usage

--- a/test/utils/_string.scss
+++ b/test/utils/_string.scss
@@ -166,6 +166,10 @@
       );
     }
 
+    @include it('Limits the number of splits with empty-string separator') {
+      @include assert-equal(string.split('hello world', '', 3), 'h' 'e' 'l');
+    }
+
     @include it('Forces $string to a string') {
       @include assert-equal(string.split(34.5, '.'), '34' '5');
     }


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&virol)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


<!--
## Description
Uncomment if you want to provide a custom description.
-->


## Steps to test/reproduce
- Play around with the `split()` function to make sure it works as expected, in particular when performing a split with an empty `$separator`.

_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._




# REMEMBER: Attach this PR to the Trello card
