### PR TITLE
Allow ignoring cached values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 ## UNRELEASED
 
-- INTERNAL: fix bug
+- INTERNAL:
+  - fix bug
   ([oddbird#112](https://github.com/oddbird/accoutrement/issues/112)) in
   [`tokens.get()`](https://www.oddbird.net/accoutrement/docs/token-api#function--get)
   memorization
+  - Upgrade dev dependencies.
 
-- INTERNAL: Upgrade dev dependencies.
+- [Tokens][token]:
+
+  - NEW: Add `$ignore-cache` parameter to `tokens.get()` function,
+    in order to override the cached value of a token.
 
 - [Sass Utilities][utils]:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 ## UNRELEASED
 
 - INTERNAL:
+
   - fix bug
-  ([oddbird#112](https://github.com/oddbird/accoutrement/issues/112)) in
-  [`tokens.get()`](https://www.oddbird.net/accoutrement/docs/token-api#function--get)
-  memorization
+    ([oddbird#112](https://github.com/oddbird/accoutrement/issues/112)) in
+    [`tokens.get()`](https://www.oddbird.net/accoutrement/docs/token-api#function--get)
+    memorization
   - Upgrade dev dependencies.
 
 - [Tokens][token]:

--- a/sass/tokens/_api.scss
+++ b/sass/tokens/_api.scss
@@ -225,6 +225,8 @@ $_memo: ();
 /// You can do the same, or use it directly
 /// to turn any arbitrary map into an Accoutrement map.
 ///
+/// @since 4.0.2 -
+/// - NEW: `$ignore-cache` argument allows overriding cached token values
 /// @since 4.0.0 -
 /// - BREAKING: Name changed from `get-token` to `get`
 /// - BREAKING: The `$key` value must be a token name for lookup,
@@ -268,14 +270,16 @@ $_memo: ();
 ///   A key to get from the map (can use nested `key->subkey` syntax)
 /// @param {map | null} $do -
 ///   A map of functional adjustments to run on the returned value
+/// @param {boolean} $ignore-cache [false] -
+///   Optionally ignore the cached value
 /// @return {*} -
 ///   The parsed value of any key in a given map
-@function get($map, $key, $do: null) {
+@function get($map, $key, $do: null, $ignore-cache: false) {
   // check the memo
   $resolved: map.get($_memo, $map, $key);
 
   // when resolved value isn't in the memo
-  @if not map.has-key($_memo, $map, $key) {
+  @if $ignore-cache or not map.has-key($_memo, $map, $key) {
     // lookup the key in the map
     $lookup: parse.lookup-alias($map, $key);
 

--- a/test/tokens/_api.scss
+++ b/test/tokens/_api.scss
@@ -150,7 +150,10 @@
       config.$handle-missing-keys: 'error';
 
       @include assert-equal(
-        (tokens.get($map, 'dop'), tokens.get($map, 'dip')),
+        (
+          tokens.get($map, 'dop', $ignore-cache: true),
+          tokens.get($map, 'dip', $ignore-cache: true)
+        ),
         (
           'ERROR [lookup-alias] Alias "ofo->nope" not found in map',
           'ERROR [lookup-alias] Alias "that->baz" not found in map'

--- a/test/tokens/_parse.scss
+++ b/test/tokens/_parse.scss
@@ -1,4 +1,5 @@
 @use '../../node_modules/sass-true/sass/true' as *;
+@use '../../sass/tokens/config';
 @use '../../sass/tokens/parse';
 @use '../../sass/tokens/function';
 @use '../../sass/tokens/register';
@@ -221,10 +222,37 @@ $scale: function.get('color.scale');
         'WARNING [lookup-alias] Alias "a->b->d" not found in map'
       );
     }
-    @include it('Optionally warn if the lookup fails') {
+
+    @include it('Optionally error if the lookup fails') {
       @include assert-equal(
         parse.lookup-alias($map, 'a->b->d', $handle-missing-keys: 'error'),
         'ERROR [lookup-alias] Alias "a->b->d" not found in map'
+      );
+    }
+
+    @include it('Use global handling for missing keys') {
+      config.$handle-missing-keys: 'error';
+
+      @include assert-equal(
+        parse.lookup-alias($map, 'a->b->d'),
+        'ERROR [lookup-alias] Alias "a->b->d" not found in map',
+        'error on missing key'
+      );
+
+      config.$handle-missing-keys: 'warn';
+
+      @include assert-equal(
+        parse.lookup-alias($map, 'a->b->d'),
+        'WARNING [lookup-alias] Alias "a->b->d" not found in map',
+        'warn on missing keys'
+      );
+
+      config.$handle-missing-keys: null;
+
+      @include assert-equal(
+        parse.lookup-alias($map, 'a->b->d'),
+        null,
+        'null on missing key'
       );
     }
   }


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&ignore-cache)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->


## Description
Uncomment if you want to provide a custom description.

- Allow ignoring the cache when getting a token
- Test that global changes to `$handle-missing-keys` are applied
- Fix test broken by cached values being returned

## Steps to test/reproduce
_Please explain how to best reproduce the issue and/or test the changes locally (including the pages/URLs/views/states to review)._

- run the tests
- check the general changelog & tokens.get documentation
