### PR TITLE
Fixed inline function adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Accoutrement Changelog
+## UNRELEASED
+
+- INTERNAL:
+
+  - Fixed a bug with [`tokens.get()`](https://www.oddbird.net/accoutrement/docs/token-api#function--get) that didn't allow per-property inline functional adjustments ([#117](https://github.com/oddbird/accoutrement/issues/117))
 
 ## 4.0.2 - 07/18/22
 

--- a/sass/tokens/_parse.scss
+++ b/sass/tokens/_parse.scss
@@ -223,7 +223,7 @@ $_stack: ();
 
     // handle each item in the list…
     @each $bit in $value {
-      $new: list.append($new, _resolve-value($map, $bit));
+      $new: list.append($new, compile-token($map, $bit));
     }
 
     @return $new;

--- a/test/tokens/_parse.scss
+++ b/test/tokens/_parse.scss
@@ -283,6 +283,12 @@ $scale: function.get('color.scale');
   @include describe('compile-token [function]') {
     $map: (
       simple: 'hello world',
+      spacers: (
+        'sm': '#spacers->md' ('-': 1em),
+        'md': 2em,
+        'lg': '#spacers->md' ('+': 1em),
+        'xl': '#spacers->lg' ('+': 1em),
+      ),
       a: (
         b: (
           c: 'world',
@@ -300,6 +306,7 @@ $scale: function.get('color.scale');
       worse: '#bad',
       h: 'hello',
       w: 'world',
+      margin: (1em ('+': '#spacers->sm')) (1em ('+': '#spacers->md')) (1em ('+': '#spacers->lg')) (1em ('+': '#spacers->xl'))
     );
 
     @include it('Has no impact on a token without references') {
@@ -420,6 +427,21 @@ $scale: function.get('color.scale');
             )
         ),
         color.scale(color.mix(mediumvioletred, $shadow, 20%), $alpha: 50%)
+      );
+    }
+    
+    @include it('Can perform multiple functional adjustments in one token') {
+      $shadow: rgba(black, 0.5);
+
+      @include assert-equal(
+        parse.compile-token(
+          $map,
+          (1em ('+': '#spacers->sm')) 
+          (1em ('+': '#spacers->md')) 
+          (1em ('+': '#spacers->lg')) 
+          (1em ('+': '#spacers->xl'))
+        ),
+        2em 3em 4em 5em
       );
     }
 

--- a/test/tokens/_parse.scss
+++ b/test/tokens/_parse.scss
@@ -431,8 +431,6 @@ $scale: function.get('color.scale');
     }
     
     @include it('Can perform multiple functional adjustments in one token') {
-      $shadow: rgba(black, 0.5);
-
       @include assert-equal(
         parse.compile-token(
           $map,


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&rockoon)

Updated _resolve-value function to call compile-token in list iterations rather than another _resolve-value to handle case scenarios where a value / do pair is provided.

Bug Described in https://github.com/oddbird/accoutrement/issues/117.
